### PR TITLE
fix: resolve ESLint errors blocking CI

### DIFF
--- a/src/core/assets.ts
+++ b/src/core/assets.ts
@@ -26,7 +26,7 @@ async function downloadFile(url: string, dest: string, retries = 3): Promise<voi
             const buffer = await response.arrayBuffer();
             await fs.writeFile(dest, Buffer.from(buffer));
             return; // Success
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (i === retries - 1) throw err; // Throw on last attempt
             const delay = Math.pow(2, i) * 1000;
             await new Promise(res => setTimeout(res, delay));
@@ -70,8 +70,7 @@ export async function makeAssetsLocal(
     // Ensure assets directory exists
     try {
         await fs.mkdir(assetsDir, { recursive: true });
-    } catch (e) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch {
         // ignore if exists
     }
 

--- a/src/templates/stats-heavy.ts
+++ b/src/templates/stats-heavy.ts
@@ -155,35 +155,6 @@ function countActive(repos: Repository[]): number {
     return repos.filter(r => !r.isArchived && r.pushedAt > threeMonthsAgo).length;
 }
 
-interface LanguageStat {
-    count: number;
-    stars: number;
-    percentage: number;
-}
-
-// function calculateLanguageStats(repos: Repository[]): Record<string, LanguageStat> {
-//     const stats: Record<string, LanguageStat> = {};
-
-//     repos.forEach(repo => {
-//         if (!repo.language) return;
-
-//         if (!stats[repo.language]) {
-//             stats[repo.language] = { count: 0, stars: 0, percentage: 0 };
-//         }
-
-//         stats[repo.language].count++;
-//         stats[repo.language].stars += repo.stars;
-//     });
-
-//     const total = Object.values(stats).reduce((sum, stat) => sum + stat.count, 0);
-
-//     Object.values(stats).forEach(stat => {
-//         stat.percentage = calculatePercentage(stat.count, total);
-//     });
-
-//     return stats;
-// }
-
 interface TimelineStat {
     count: number;
     stars: number;


### PR DESCRIPTION
## Summary
- Fixes unused catch binding / eslint-disable noise in `makeAssetsLocal`
- Removes unused `LanguageStat` interface and related commented-out dead code that failed `@typescript-eslint/no-unused-vars`
- Also tightens `catch (err: unknown)` so `pnpm lint` is clean

Closes #7.

## Test plan
- [ ] `pnpm install`
- [ ] `pnpm lint` exits 0
- [ ] CI lint job on this PR is green